### PR TITLE
Fix ETH symbol

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -11,7 +11,7 @@
 	"networks": [
 		{
 			"name": "Hemi Testnet",
-			"nativeCurrency": "thETH",
+			"nativeCurrency": "ETH",
 			"RPC_URL": "https://testnet.rpc.hemi.network/rpc",
 			"scan": "https://testnet.explorer.hemi.xyz"
 		}


### PR DESCRIPTION
This PR just renames `thETH` to `ETH` to follow the agreed naming convention.